### PR TITLE
Fix three bugs in the component tests

### DIFF
--- a/packages/python/openproblems/CHANGELOG.md
+++ b/packages/python/openproblems/CHANGELOG.md
@@ -37,6 +37,18 @@
   Viash does. `os.path.join()` treats such a path as absolute and silently dropped the project
   root, so a config containing e.g. `__merge__: /src/api/file_dataset.yaml` failed to read.
 
+* `check_config`: Check the required links even when a component defines no links at all.
+  `check_links` returned early on an empty `links`, so a method without any links passed,
+  while a method with only a `documentation` link was told that `.links.repository` is missing.
+
+* `check_config`: Give `check_url` a 30 second timeout, and report a request that fails outright
+  as an unreachable link rather than letting the exception escape.
+
+* `check_config`: Escape the dot in the DOI regex, which also matched a prefix like `10X1038`.
+
+* `run_and_check_output`: Skip the format validation of an output file argument that has no
+  value. An optional output without a default or example crashed with a `KeyError: 'value'`.
+
 # openproblems core Python v0.1.1
 
 ## NEW FUNCTIONALITY

--- a/packages/python/openproblems/pyproject.toml
+++ b/packages/python/openproblems/pyproject.toml
@@ -33,7 +33,9 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-  "pytest>=8.0"
+  "pytest>=8.0",
+  # imported inside check_url(), so not a runtime dependency of the package
+  "requests"
 ]
 
 [project.urls]

--- a/packages/python/openproblems/src/openproblems/project/component_tests/check_config.py
+++ b/packages/python/openproblems/src/openproblems/project/component_tests/check_config.py
@@ -60,8 +60,7 @@ def check_references(references: Dict[str, Union[str, List[str]]]) -> None:
 def check_links(
     links: Dict[str, Union[str, List[str]]], required: List[str] = []
 ) -> None:
-    if not links:
-        return
+    links = links or {}
 
     for expected_link in required:
         assert expected_link in links, f"Link .links.{expected_link} is not defined"

--- a/packages/python/openproblems/src/openproblems/project/component_tests/check_config.py
+++ b/packages/python/openproblems/src/openproblems/project/component_tests/check_config.py
@@ -49,7 +49,7 @@ def check_references(references: Dict[str, Union[str, List[str]]]) -> None:
             doi = [doi]
         for d in doi:
             assert re.match(
-                r"^10.\d{4,9}/[-._;()/:A-Za-z0-9]+$", d
+                r"^10\.\d{4,9}/[-._;()/:A-Za-z0-9]+$", d
             ), f"Invalid DOI format: {doi}"
             assert check_url(f"https://doi.org/{d}"), f"DOI '{d}' is not reachable"
 

--- a/packages/python/openproblems/src/openproblems/project/component_tests/check_config.py
+++ b/packages/python/openproblems/src/openproblems/project/component_tests/check_config.py
@@ -9,12 +9,15 @@ LABEL_MAXLEN = 50
 SUMMARY_MAXLEN = 400
 DESCRIPTION_MAXLEN = 5000
 
+# seconds to wait for a link or doi to respond
+URL_TIMEOUT = 30
+
 TIME_LABELS = ["lowtime", "midtime", "hightime", "veryhightime"]
 MEM_LABELS = ["lowmem", "midmem", "highmem", "veryhighmem"]
 CPU_LABELS = ["lowcpu", "midcpu", "highcpu", "veryhighcpu"]
 
 
-def check_url(url: str) -> bool:
+def check_url(url: str, timeout: int = URL_TIMEOUT) -> bool:
     import requests
     from urllib3.util.retry import Retry
     from requests.adapters import HTTPAdapter
@@ -25,12 +28,12 @@ def check_url(url: str) -> bool:
     session.mount("http://", adapter)
     session.mount("https://", adapter)
 
-    get = session.head(url)
-
-    if get.ok or get.status_code == 429:  # 429 rejected, too many requests
-        return True
-    else:
+    try:
+        get = session.head(url, timeout=timeout)
+    except requests.exceptions.RequestException:
         return False
+
+    return get.ok or get.status_code == 429  # 429 rejected, too many requests
 
 
 def check_references(references: Dict[str, Union[str, List[str]]]) -> None:

--- a/packages/python/openproblems/src/openproblems/project/component_tests/run_and_check_output.py
+++ b/packages/python/openproblems/src/openproblems/project/component_tests/run_and_check_output.py
@@ -47,7 +47,7 @@ def check_output_files(arguments: list) -> None:
 def check_format(arg: dict) -> None:
     """Read an output file and validate its contents against the format spec."""
     arg_info = arg.get("info") or {}
-    if arg["type"] == "file":
+    if arg["type"] == "file" and arg.get("value") is not None:
         arg_format = arg_info.get("format", {})
         file_type = arg_format.get("type") or arg_info.get("file_type")
 

--- a/packages/python/openproblems/tests/test_project_check_config.py
+++ b/packages/python/openproblems/tests/test_project_check_config.py
@@ -47,6 +47,26 @@ def test_check_url_passes_a_timeout_and_survives_a_failure():
         assert not check_url("https://example.com")
 
 
+def test_check_references_rejects_a_malformed_doi():
+    from openproblems.project.component_tests.check_config import check_references
+
+    with pytest.raises(AssertionError, match="Invalid DOI format"):
+        check_references({"doi": "10X1038/s41592-024-02189-7"})
+
+
+def test_check_references_accepts_a_bibtex_entry():
+    from openproblems.project.component_tests.check_config import check_references
+
+    check_references({"bibtex": "@article{key, title={A title}}"})
+
+
+def test_check_references_requires_a_doi_or_bibtex():
+    from openproblems.project.component_tests.check_config import check_references
+
+    with pytest.raises(AssertionError, match="should be defined"):
+        check_references({})
+
+
 def test_check_links_requires_the_expected_links():
     from openproblems.project.component_tests.check_config import check_links
 

--- a/packages/python/openproblems/tests/test_project_check_config.py
+++ b/packages/python/openproblems/tests/test_project_check_config.py
@@ -30,6 +30,23 @@ def test_check_config_accepts_resource_labels():
     check_config(_config())
 
 
+def test_check_url_passes_a_timeout_and_survives_a_failure():
+    import requests
+    from unittest import mock
+    from openproblems.project.component_tests.check_config import (
+        URL_TIMEOUT,
+        check_url,
+    )
+
+    with mock.patch.object(requests.Session, "head") as head:
+        head.return_value = mock.Mock(ok=True, status_code=200)
+        assert check_url("https://example.com")
+        assert head.call_args.kwargs["timeout"] == URL_TIMEOUT
+
+        head.side_effect = requests.exceptions.ConnectTimeout()
+        assert not check_url("https://example.com")
+
+
 def test_check_links_requires_the_expected_links():
     from openproblems.project.component_tests.check_config import check_links
 

--- a/packages/python/openproblems/tests/test_project_check_config.py
+++ b/packages/python/openproblems/tests/test_project_check_config.py
@@ -30,6 +30,14 @@ def test_check_config_accepts_resource_labels():
     check_config(_config())
 
 
+def test_check_links_requires_the_expected_links():
+    from openproblems.project.component_tests.check_config import check_links
+
+    for links in [{}, None, {"documentation": "https://example.com"}]:
+        with pytest.raises(AssertionError, match="Link .links.repository"):
+            check_links(links, ["repository"])
+
+
 def test_check_config_requires_a_nextflow_runner():
     with pytest.raises(AssertionError, match="does not contain a nextflow runner"):
         check_config(_config(runners=[{"type": "executable"}]))

--- a/packages/python/openproblems/tests/test_project_run_and_check_output.py
+++ b/packages/python/openproblems/tests/test_project_run_and_check_output.py
@@ -1,0 +1,46 @@
+import pytest
+
+from openproblems.project.component_tests.run_and_check_output import (
+    check_output_files,
+    generate_cmd_args,
+    get_argument_sets,
+)
+
+
+def _arg(**kwargs):
+    arg = {
+        "name": "--output",
+        "clean_name": "output",
+        "type": "file",
+        "direction": "output",
+        "required": False,
+        "must_exist": True,
+        "multiple": False,
+        "multiple_sep": ";",
+    }
+    arg.update(kwargs)
+    return arg
+
+
+def test_check_output_files_skips_arguments_without_a_value():
+    # an optional output without a default or example never gets a value, so
+    # there is no file to read
+    arg = _arg(info={"format": {"type": "h5ad", "obs": [{"name": "label"}]}})
+    check_output_files([arg])
+
+
+def test_check_output_files_requires_required_outputs():
+    arg = _arg(required=True, info={})
+    with pytest.raises(AssertionError, match="is missing a value"):
+        check_output_files([arg])
+
+
+def test_get_argument_sets_leaves_valueless_arguments_alone():
+    config = {
+        "argument_groups": [{"name": "Arguments", "arguments": [_arg(info={})]}],
+        "all_arguments": [_arg(info={})],
+    }
+    argument_sets = get_argument_sets(config, "resources")
+
+    assert "value" not in argument_sets["run"][0]
+    assert generate_cmd_args(argument_sets["run"]) == []

--- a/packages/python/openproblems/tox.ini
+++ b/packages/python/openproblems/tox.ini
@@ -8,6 +8,7 @@ description = run unit tests
 deps =
     pytest>=7
     pytest-sugar
+    requests
 commands =
     pytest {posargs:tests}
 


### PR DESCRIPTION
These all run in `viash ns test` for every component in every task repo.

## The required links were not checked when there were none

`check_links()` returned early on an empty `links`, before asserting that the required ones are present:

```python
check_links({}, ["documentation", "repository"])                     # passed
check_links({"documentation": ...}, ["documentation", "repository"])  # "Link .links.repository is not defined"
```

So a method without any links passed, and a method with a partial `links` block failed -- the wrong way around, since methods are exactly where those links are mandatory.

## An optional output crashed the test

The format validation loop in `check_output_files()` does not filter on `required` the way the existence check above it does. An optional output argument without a default or example never gets a value assigned, so `check_format()` fell over with a bare `KeyError: 'value'` instead of skipping it.

## `check_url()` had no timeout

`head()` without a timeout waits forever on an unresponsive host, and every component test checks all the links and dois in its config. It now uses a 30 second timeout, and a request that fails outright reports the link as unreachable instead of letting a `ConnectionError` escape as a traceback.

## Also

`^10.\d{4,9}/` matched a doi prefix like `10X1038`, since the dot was not escaped.

## Tests

`check_links`, `check_references` and `check_url` had no tests at all; `run_and_check_output` had none either. Added a few for the paths touched here -- the link and output ones fail on `main`.