### PR TITLE
Make the lint and type checks actually run

### DIFF
--- a/.github/workflows/python-packages.yaml
+++ b/.github/workflows/python-packages.yaml
@@ -31,6 +31,28 @@ jobs:
       run: |
         cd packages/python/${{ matrix.package }}
         tox -e lint
+
+  type:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [openproblems]
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Using Python 3.10
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.10"
+
+    - name: Install tox
+      run: python -m pip install tox
+
+    - name: Run tox type
+      run: |
+        cd packages/python/${{ matrix.package }}
+        tox -e type
   test:
     runs-on: ubuntu-latest
 

--- a/packages/python/openproblems/CHANGELOG.md
+++ b/packages/python/openproblems/CHANGELOG.md
@@ -24,6 +24,12 @@
 
 * `check_config`: Skip the Nextflow resource label check for components whose script is itself a Nextflow workflow. Viash renders those as a workflow rather than a process, so the labels would have no effect.
 
+* `tox -e lint` now checks the formatting rather than applying it, so the lint job can actually fail.
+  Run `black` yourself, or `tox -e lint -- .`, to apply the changes.
+
+* The `type` environment is no longer skipped in CI, and the 25 type errors it had accumulated
+  are fixed.
+
 ## BUG FIXES
 
 * `read_task_metadata`: Order the task graph topologically instead of by a breadth-first search from a single root.

--- a/packages/python/openproblems/pyproject.toml
+++ b/packages/python/openproblems/pyproject.toml
@@ -51,3 +51,17 @@ exclude = ["tests*"]
 
 [tool.setuptools_scm]
 root = "../../.."
+
+# the component tests import these inside the function that needs them, so that
+# a task repo only has to provide the ones its own components use
+[[tool.mypy.overrides]]
+module = [
+  "anndata.*",
+  "networkx.*",
+  "pandas.*",
+  "requests.*",
+  "spatialdata.*",
+  "urllib3.*",
+  "yaml.*",
+]
+ignore_missing_imports = true

--- a/packages/python/openproblems/src/openproblems/project/component_tests/check_config.py
+++ b/packages/python/openproblems/src/openproblems/project/component_tests/check_config.py
@@ -60,9 +60,7 @@ def check_references(references: Dict[str, Union[str, List[str]]]) -> None:
             assert re.match(r"^@.*{.*", b), f"Invalid bibtex format: {b}"
 
 
-def check_links(
-    links: Dict[str, Union[str, List[str]]], required: List[str] = []
-) -> None:
+def check_links(links: Dict[str, str], required: List[str] = []) -> None:
     links = links or {}
 
     for expected_link in required:

--- a/packages/python/openproblems/src/openproblems/project/component_tests/check_config.py
+++ b/packages/python/openproblems/src/openproblems/project/component_tests/check_config.py
@@ -122,13 +122,18 @@ def check_config(config: dict) -> None:
     print("Check that .namespace is defined", flush=True)
     assert config.get("namespace"), ".namespace is not defined"
 
-    print("Check that .info.type is 'method', 'control_method', or 'metric'", flush=True)
+    print(
+        "Check that .info.type is 'method', 'control_method', or 'metric'", flush=True
+    )
     expected_types = ["method", "control_method", "metric"]
     assert (
         comp_type in expected_types
     ), f".info.type is '{comp_type}' but should be one of: {', '.join(expected_types)}"
 
-    print("Check component metadata fields (name, label, summary, description)", flush=True)
+    print(
+        "Check component metadata fields (name, label, summary, description)",
+        flush=True,
+    )
     if comp_type == "metric":
         metric_infos = info.get("metrics", [])
         assert metric_infos, ".info.metrics is not defined"
@@ -138,7 +143,10 @@ def check_config(config: dict) -> None:
         check_info(info, config, comp_type=comp_type)
 
     if "preferred_normalization" in info:
-        print("Check that .info.preferred_normalization is a valid normalization method", flush=True)
+        print(
+            "Check that .info.preferred_normalization is a valid normalization method",
+            flush=True,
+        )
         norm_methods = [
             "log_cpm",
             "log_cp10k",
@@ -155,7 +163,9 @@ def check_config(config: dict) -> None:
         )
 
     if "variants" in info:
-        print("Check that .info.variants only references valid argument names", flush=True)
+        print(
+            "Check that .info.variants only references valid argument names", flush=True
+        )
         arg_names = [arg["clean_name"] for arg in config["all_arguments"]] + [
             "preferred_normalization"
         ]
@@ -185,7 +195,9 @@ def check_config(config: dict) -> None:
     )
 
     if not is_nextflow_workflow:
-        print("Check that the Nextflow runner has time, mem, and cpu labels", flush=True)
+        print(
+            "Check that the Nextflow runner has time, mem, and cpu labels", flush=True
+        )
         assert nextflow_runner.get(
             "directives"
         ), "directives not a field in nextflow runner"

--- a/packages/python/openproblems/src/openproblems/project/component_tests/run_and_check_output.py
+++ b/packages/python/openproblems/src/openproblems/project/component_tests/run_and_check_output.py
@@ -22,8 +22,12 @@ def check_input_files(arguments: list) -> None:
     for arg in arguments:
         if arg["type"] == "file" and arg["direction"] == "input" and arg["required"]:
             expected_path = arg.get("value")
-            assert expected_path is not None, f"Input argument '{arg['name']}' is missing a value"
-            assert not arg["must_exist"] or path.exists(expected_path), f"Input file '{expected_path}' does not exist"
+            assert (
+                expected_path is not None
+            ), f"Input argument '{arg['name']}' is missing a value"
+            assert not arg["must_exist"] or path.exists(
+                expected_path
+            ), f"Input file '{expected_path}' does not exist"
 
 
 def check_output_files(arguments: list) -> None:
@@ -34,8 +38,12 @@ def check_output_files(arguments: list) -> None:
     for arg in arguments:
         if arg["type"] == "file" and arg["direction"] == "output" and arg["required"]:
             expected_path = arg.get("value")
-            assert expected_path is not None, f"Output argument '{arg['name']}' is missing a value"
-            assert not arg["must_exist"] or path.exists(expected_path), f"Output file '{expected_path}' does not exist"
+            assert (
+                expected_path is not None
+            ), f"Output argument '{arg['name']}' is missing a value"
+            assert not arg["must_exist"] or path.exists(
+                expected_path
+            ), f"Output file '{expected_path}' does not exist"
 
     print(">> Validating the contents and format of output files", flush=True)
     for arg in arguments:

--- a/packages/python/openproblems/src/openproblems/project/read_nested_yaml.py
+++ b/packages/python/openproblems/src/openproblems/project/read_nested_yaml.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 
 def read_nested_yaml(path: str, project_path: str | None = None) -> dict:
     """
@@ -35,8 +37,8 @@ def read_nested_yaml(path: str, project_path: str | None = None) -> dict:
 
 
 def process_nested_yaml(
-    data: any, root_data: dict, path: str, project_path: str
-) -> dict:
+    data: Any, root_data: dict, path: str, project_path: str | None
+) -> Any:
     """
     Process the merge keys in a YAML
 
@@ -62,7 +64,7 @@ def process_nested_yaml(
             for k, v in data.items()
         }
 
-        new_data = {}
+        new_data: Any = {}
         if "__merge__" in processed_data and not isinstance(
             processed_data["__merge__"], dict
         ):

--- a/packages/python/openproblems/src/openproblems/utils/deep_merge.py
+++ b/packages/python/openproblems/src/openproblems/utils/deep_merge.py
@@ -1,4 +1,7 @@
-def deep_merge(obj1: any, obj2: any) -> dict:
+from typing import Any
+
+
+def deep_merge(obj1: Any, obj2: Any) -> Any:
     """Recursively merge two dictionaries or lists.
 
     Args:

--- a/packages/python/openproblems/tox.ini
+++ b/packages/python/openproblems/tox.ini
@@ -17,7 +17,7 @@ description = run linters
 skip_install = true
 deps =
     black==22.12
-commands = black {posargs:.}
+commands = black {posargs:--check --diff .}
 
 [testenv:type]
 description = run type checks

--- a/packages/python/openproblems/tox.ini
+++ b/packages/python/openproblems/tox.ini
@@ -23,5 +23,6 @@ commands = black {posargs:--check --diff .}
 description = run type checks
 deps =
     mypy>=0.991
+    pytest>=7
 commands =
     mypy {posargs:src tests}


### PR DESCRIPTION
## The lint job could not fail

`tox -e lint` ran `black .` -- which reformats the files in the runner, discards the result and exits 0. Two files were unformatted on `main` while CI was green. It now runs `black --check --diff .`; `tox -e lint -- .` still applies the changes.

The first commit is that reformat on its own, so the rest of the diff stays readable.

## The type checks never ran

`tox.ini` has had a `type` env since the start, but nothing invoked it: the test job skips every env that is not `py<version>` (`--skip-env '^(?!py310).+'`) and the lint job only runs `lint`. It had quietly accumulated 25 errors, so this adds a `type` job alongside `lint` and clears them:

* `deep_merge()` and `process_nested_yaml()` annotated their arguments as `any` -- the builtin function -- rather than `typing.Any`
* `process_nested_yaml()` did not accept a `project_path` of `None`, which is what `read_nested_yaml()` hands it for a yaml outside a viash project
* `check_links()` said the values of `.links` may be lists of urls. They are urls -- see `Links` in `schemas/schema_viash.yaml` -- and `check_url()` would have choked on a list
* anndata, pandas, requests, networkx, spatialdata, urllib3 and yaml have no type information, and are imported inside the function that needs them so a task repo only provides the ones its own components use. They get an `ignore_missing_imports` override

`tox -e lint`, `tox -e type` and `tox run -e py310` all pass.